### PR TITLE
Add neuromorphic portfolio scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,20 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Neuromorphic Engineer Portfolio
 
-## Getting Started
+This project is a personal portfolio built with **Next.js**, **Tailwind CSS**, and **Framer Motion**. It demonstrates a simple layout with dark/light mode, animated background, and several content pages.
 
-First, run the development server:
+## Available Scripts
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm run dev       # start the dev server
+npm run build     # build for production
+npm start         # start the production server
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Features
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- Animated brain‑to‑chip background using Framer Motion
+- Dark and light themes powered by `next-themes`
+- Responsive layout with Tailwind CSS
+- Placeholder pages for About, Projects, Publications, Blog and Contact
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-# DevPortfolio-
-# DevPortfolio-
-# portfolio
-# portfolio
-# portfolio
+The site is ready to be deployed on [Vercel](https://vercel.com/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "framer-motion": "^12.23.6",
         "lucide-react": "^0.525.0",
         "next": "15.4.1",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "tailwind-merge": "^3.3.1"
@@ -5398,6 +5399,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^12.23.6",
     "lucide-react": "^0.525.0",
     "next": "15.4.1",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1"

--- a/public/assets/brain.svg
+++ b/public/assets/brain.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none" stroke="currentColor" stroke-width="4">
+  <path d="M40 100c-15-35 15-70 40-70s20 20 20 20 0-20 20-20 55 35 40 70c20 0 20 30 0 30 0 25-25 40-40 40s-20-20-20-20 0 20-20 20-55-15-40-40c-20 0-20-30 0-30z" />
+</svg>

--- a/public/assets/chip.svg
+++ b/public/assets/chip.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none" stroke="currentColor" stroke-width="4">
+  <rect x="50" y="50" width="100" height="100" rx="10" />
+  <rect x="80" y="80" width="40" height="40" />
+  <path d="M100 30v20M100 150v20M30 100h20M150 100h20" />
+</svg>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,16 @@
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+
+export default function About() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1 container mx-auto px-4 py-24 space-y-6">
+        <h1 className="text-3xl font-bold mb-4">About Me</h1>
+        <p>My work bridges biology and silicon — designing chips that don’t just compute, but think.</p>
+        <p>Currently a Staff Software Engineer at Google focusing on advanced neuromorphic computing.</p>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,39 @@
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+
+const posts = [
+  {
+    title: 'Why Event-Based Processing Will Outlive the Von Neumann Model',
+    date: '2024-01-01',
+    summary: 'A short overview of event-driven architectures.',
+    link: '#'
+  },
+  {
+    title: 'Designing for Fault Tolerance in Neuromorphic Meshes',
+    date: '2024-02-01',
+    summary: 'Building resilient neural fabrics.',
+    link: '#'
+  }
+]
+
+export default function Blog() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1 container mx-auto px-4 py-24 space-y-6">
+        <h1 className="text-3xl font-bold mb-4">Blog</h1>
+        <ul className="space-y-6">
+          {posts.map(p => (
+            <li key={p.title} className="border rounded-md p-4">
+              <h3 className="font-semibold text-lg mb-1">{p.title}</h3>
+              <p className="text-xs text-muted-foreground mb-2">{p.date}</p>
+              <p className="text-sm mb-2">{p.summary}</p>
+              <a href={p.link} className="text-primary underline text-sm">Read More</a>
+            </li>
+          ))}
+        </ul>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,21 @@
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import Link from 'next/link'
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1 container mx-auto px-4 py-24 space-y-6 text-center">
+        <h1 className="text-3xl font-bold mb-4">Contact</h1>
+        <p>You can reach me via email or follow my work online.</p>
+        <div className="space-x-4">
+          <Link href="mailto:neuromorph@example.com" className="underline">Email</Link>
+          <Link href="https://github.com" className="underline">GitHub</Link>
+          <Link href="https://linkedin.com" className="underline">LinkedIn</Link>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,8 +6,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-jetbrains);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetBrains = JetBrains_Mono({
+  variable: "--font-jetbrains",
   subsets: ["latin"],
 });
 
@@ -23,11 +24,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} ${jetBrains.variable} antialiased`}>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,19 @@
-import Image from "next/image";
+import Link from 'next/link'
+import BrainToChipAnimation from '@/components/BrainToChipAnimation'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+    <div className="relative flex flex-col min-h-screen">
+      <BrainToChipAnimation />
+      <Navbar />
+      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 gap-6 backdrop-blur-sm bg-black/60 dark:bg-black/40">
+        <h1 className="text-4xl md:text-6xl font-bold">Engineering the Future of Thought</h1>
+        <p className="text-lg md:text-xl">Staff Software Engineer @ Google • Neuromorphic Hardware • Systems Design</p>
+        <Link href="/projects" className="px-6 py-3 bg-primary text-primary-foreground rounded-md">See My Work</Link>
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      <Footer />
     </div>
-  );
+  )
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,35 @@
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import ProjectCard from '@/components/ProjectCard'
+
+const projects = [
+  {
+    title: 'NeuroSim v2',
+    description: 'High-efficiency event-driven simulator for brain-like architectures.',
+    stack: ['Rust', 'CUDA', 'PyTorch'],
+    github: 'https://github.com/example/neurosim'
+  },
+  {
+    title: 'CortexX',
+    description: 'High-throughput Neuromorphic Simulator',
+    stack: ['Go', 'WebGPU'],
+    github: '#'
+  }
+]
+
+export default function Projects() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1 container mx-auto px-4 py-24 space-y-6">
+        <h1 className="text-3xl font-bold mb-4">Projects</h1>
+        <div className="grid sm:grid-cols-2 gap-6">
+          {projects.map(p => (
+            <ProjectCard key={p.title} project={p} />
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/publications/page.tsx
+++ b/src/app/publications/page.tsx
@@ -1,0 +1,33 @@
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+
+const publications = [
+  {
+    title: 'Neuromorphic Circuits for Adaptive Control',
+    journal: 'Journal of Neural Engineering',
+    link: '#',
+    abstract: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+  }
+]
+
+export default function Publications() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1 container mx-auto px-4 py-24 space-y-6">
+        <h1 className="text-3xl font-bold mb-4">Publications</h1>
+        <ul className="space-y-4">
+          {publications.map(p => (
+            <li key={p.title} className="border p-4 rounded-md">
+              <h3 className="font-semibold text-lg">{p.title}</h3>
+              <p className="text-sm text-muted-foreground">{p.journal}</p>
+              <p className="text-sm mt-2">{p.abstract}</p>
+              <a href={p.link} className="text-primary underline text-sm mt-2 inline-block">Read</a>
+            </li>
+          ))}
+        </ul>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/components/BrainToChipAnimation.tsx
+++ b/src/components/BrainToChipAnimation.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Image from 'next/image'
+import { motion, useCycle } from 'framer-motion'
+import { useEffect } from 'react'
+
+export default function BrainToChipAnimation() {
+  const [brain, toggle] = useCycle(true, false)
+
+  useEffect(() => {
+    const id = setInterval(() => toggle(), 8000)
+    return () => clearInterval(id)
+  }, [toggle])
+
+  return (
+    <div className="absolute inset-0 -z-10 overflow-hidden">
+      <motion.div
+        className="absolute inset-0 flex items-center justify-center"
+        animate={{ opacity: brain ? 1 : 0 }}
+        transition={{ duration: 2 }}
+      >
+        <Image src="/assets/brain.svg" alt="brain" fill className="object-contain opacity-30" />
+      </motion.div>
+      <motion.div
+        className="absolute inset-0 flex items-center justify-center"
+        animate={{ opacity: brain ? 0 : 1 }}
+        transition={{ duration: 2 }}
+      >
+        <Image src="/assets/chip.svg" alt="chip" fill className="object-contain opacity-30" />
+      </motion.div>
+    </div>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="py-6 text-center text-sm text-muted-foreground">
+      <p>
+        © {new Date().getFullYear()} Neuromorphic Engineer Portfolio. Built with Next.js.
+      </p>
+    </footer>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import ThemeToggle from './ThemeToggle'
+
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/about', label: 'About' },
+  { href: '/projects', label: 'Projects' },
+  { href: '/publications', label: 'Publications' },
+  { href: '/blog', label: 'Blog' },
+  { href: '/contact', label: 'Contact' },
+]
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <header className="fixed top-0 left-0 w-full z-20 backdrop-blur-md bg-background/70 border-b">
+      <nav className="max-w-7xl mx-auto flex items-center justify-between p-4">
+        <Link href="/" className="font-mono font-semibold">NEURO</Link>
+        <button
+          className="sm:hidden" onClick={() => setOpen(!open)}
+          aria-label="Toggle Menu"
+        >
+          ☰
+        </button>
+        <ul className={`gap-6 sm:flex ${open ? 'block mt-4' : 'hidden'} sm:mt-0`}> 
+          {links.map((l) => (
+            <li key={l.href}>
+              <Link href={l.href} className="hover:underline" onClick={() => setOpen(false)}>
+                {l.label}
+              </Link>
+            </li>
+          ))}
+          <li>
+            <ThemeToggle />
+          </li>
+        </ul>
+      </nav>
+    </header>
+  )
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+interface Project {
+  title: string
+  description: string
+  stack: string[]
+  github?: string
+}
+
+export default function ProjectCard({ project }: { project: Project }) {
+  return (
+    <div className="p-4 border rounded-lg bg-card">
+      <h3 className="font-semibold text-lg mb-2">{project.title}</h3>
+      <p className="mb-2 text-sm text-muted-foreground">{project.description}</p>
+      <ul className="flex flex-wrap gap-2 text-xs mb-2">
+        {project.stack.map(s => (
+          <li key={s} className="px-2 py-0.5 bg-muted rounded">
+            {s}
+          </li>
+        ))}
+      </ul>
+      {project.github && (
+        <Link href={project.github} className="text-sm text-primary underline">
+          GitHub
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      aria-label="Toggle Dark Mode"
+      className="px-2 py-1 rounded border"
+    >
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  )
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,20 @@
+import defaultTheme from 'tailwindcss/defaultTheme'
+
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: [
+    './src/app/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', ...defaultTheme.fontFamily.sans],
+        mono: ['var(--font-jetbrains)', ...defaultTheme.fontFamily.mono],
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- use Inter and JetBrains Mono fonts with theme provider
- add Tailwind config and dark/light theme toggle
- implement animated brain-to-chip background
- scaffold pages: home, about, projects, publications, blog, contact
- include Navbar, Footer, project cards
- add placeholder SVG assets

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_b_687a67779f808322b58a4a807ae77e2e