### PR TITLE
Enable scrolling navigation between pages

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,23 +4,26 @@ import { ThemeProvider } from 'next-themes'
 import { AnimatePresence, motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import CommandPalette from './CommandPalette'
+import ScrollNavigator from './ScrollNavigator'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
       <CommandPalette />
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={pathname}
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          transition={{ duration: 0.3 }}
-        >
-          {children}
-        </motion.div>
-      </AnimatePresence>
+      <ScrollNavigator>
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={pathname}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.3 }}
+          >
+            {children}
+          </motion.div>
+        </AnimatePresence>
+      </ScrollNavigator>
     </ThemeProvider>
   )
 }

--- a/src/components/ScrollNavigator.tsx
+++ b/src/components/ScrollNavigator.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+
+const order = ['/', '/about', '/projects', '/publications', '/blog', '/contact']
+
+export default function ScrollNavigator({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    let last = 0
+    const onWheel = (e: WheelEvent) => {
+      const now = Date.now()
+      if (now - last < 1000) return
+      const index = order.indexOf(pathname)
+      if (index === -1) return
+      if (e.deltaY > 50 && index < order.length - 1) {
+        last = now
+        router.push(order[index + 1])
+      } else if (e.deltaY < -50 && index > 0) {
+        last = now
+        router.push(order[index - 1])
+      }
+    }
+    window.addEventListener('wheel', onWheel, { passive: true })
+    return () => window.removeEventListener('wheel', onWheel)
+  }, [pathname, router])
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- allow scrolling between routes in order `/` → `/about` → `/projects` → `/publications` → `/blog` → `/contact`
- wrap the entire app with `ScrollNavigator` to intercept mouse wheel events

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687e70799f64832295132d4ef567e33a