### PR TITLE
Add profile card to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowRight } from 'lucide-react'
 import BrainToChipAnimation from '@/components/BrainToChipAnimation'
-import Image from 'next/image'
+import ProfileCard from '@/components/ProfileCard'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -13,18 +13,8 @@ export default function Home() {
     <div className="relative flex flex-col min-h-screen bg-black">
       <BrainToChipAnimation isHovered={isHovered} />
 
-      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 z-10">
-        <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-white">LETO HILLZA</h1>
-        <p className="mt-4 text-lg md:text-xl text-neutral-400 flex items-center justify-center gap-1">
-          Senior Staff Software Engineer @
-          <Image
-            src="https://upload.wikimedia.org/wikipedia/commons/2/2f/Google_2015_logo.svg"
-            alt="Google logo"
-            width={20}
-            height={20}
-            className="inline-block h-5 w-5 align-text-bottom ml-1"
-          />
-        </p>
+      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 z-10 space-y-8">
+        <ProfileCard />
 
         <Link
           href="/about"

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import Image from 'next/image'
+
+export default function ProfileCard() {
+  return (
+    <div className="flex flex-col items-center p-6 bg-background/80 rounded-xl shadow-lg border backdrop-blur-md w-72">
+      <div className="relative w-32 h-32 mb-4">
+        <Image
+          src="/images/hillza.jpeg"
+          alt="Leto Hillza"
+          fill
+          className="rounded-full object-cover border-2 border-primary"
+        />
+      </div>
+      <h2 className="text-2xl font-semibold">Leto Hillza</h2>
+      <p className="text-muted-foreground">Senior Staff Software Engineer</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce `ProfileCard` component with circular image and title
- add card to the homepage layout
- include `public/images` directory placeholder

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687e8210155c8322adae8a5a11d4eb8a