### PR TITLE
Improve ProfileCard and page layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,11 +19,11 @@ export default function Home() {
         </div>
         <Link
           href="/about"
-          className="mt-8 inline-flex items-center gap-2 px-8 py-3 text-lg text-white border border-neutral-600 rounded-full hover:bg-white hover:text-black transition-colors duration-300"
+          className="mt-12 inline-flex items-center gap-2.5 px-10 py-4 text-xl text-white border border-neutral-600 rounded-full hover:bg-white hover:text-black transition-colors duration-300"
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
-          Enter <ArrowRight size={20} />
+          Enter <ArrowRight size={22} />
         </Link>
       </main>
     </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -9,25 +9,36 @@ export default function ProfileCard() {
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.5, ease: 'easeOut' }}
-      className="relative flex flex-col items-center text-center p-6 w-80 group"
+      className="relative flex flex-col items-center text-center p-6 w-96 group"
     >
-      {/* Subtle background glow */}
-      <div className="absolute -inset-4 bg-primary/10 dark:bg-primary/5 rounded-full blur-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+      {/* Increased blur and spread for a softer, larger glow */}
+      <div className="absolute -inset-8 bg-primary/10 dark:bg-primary/5 rounded-full blur-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
 
-      <div className="relative w-32 h-32 mb-6">
+      {/* Larger image */}
+      <div className="relative w-40 h-40 mb-6">
         <Image
           src="/images/hillza.jpeg"
           alt="Leto Hillza"
           fill
           className="rounded-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500"
-          sizes="128px"
+          sizes="160px"
+          priority
         />
-        {/* Ring accent */}
-        <div className="absolute -inset-1 rounded-full border-2 border-primary/20 dark:border-primary/30 group-hover:border-primary/50 transition-all duration-500" />
+        {/* Larger ring accent */}
+        <div className="absolute -inset-2 rounded-full border-2 border-primary/20 dark:border-primary/30 group-hover:border-primary/50 transition-all duration-500" />
       </div>
 
-      <h2 className="text-2xl font-semibold tracking-tight">Leto Hillza</h2>
-      <p className="text-muted-foreground mt-1">Senior Staff Software Engineer</p>
+      {/* Increased font size and weight for the name */}
+      <h2 className="text-4xl font-bold tracking-tight text-foreground">Leto Hillza</h2>
+      {/* Clearer, larger title */}
+      <p className="text-lg text-foreground/80 mt-2">Senior Staff Software Engineer</p>
+
+      {/* Company and Location information */}
+      <div className="mt-3 text-md text-muted-foreground flex items-center gap-x-3">
+        <span>Google</span>
+        <span className="text-xs">•</span>
+        <span>Atlanta, GA</span>
+      </div>
     </motion.div>
   )
 }


### PR DESCRIPTION
## Summary
- enlarge glow and image in `ProfileCard`
- show company/location and adjust typography
- scale up the `Enter` button on the home page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e8c7df9d4832295492100090457e9