### PR TITLE
Improve mobile parity

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,8 @@ export default function Home() {
           className="mt-12 inline-flex items-center gap-2.5 px-10 py-4 text-xl text-white border border-neutral-600 rounded-full hover:bg-white hover:text-black transition-colors duration-300"
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
+          onTouchStart={() => setIsHovered(true)}
+          onTouchEnd={() => setIsHovered(false)}
         >
           Enter <ArrowRight size={22} />
         </Link>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@
 
 import { Command } from 'cmdk'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useTheme } from 'next-themes'
 
 const pages = [
@@ -11,8 +11,13 @@ const pages = [
   { label: 'Projects', href: '/projects' },
 ]
 
-export default function CommandPalette() {
-  const [open, setOpen] = useState(false)
+export default function CommandPalette({
+  open,
+  setOpen,
+}: {
+  open: boolean
+  setOpen: (open: boolean) => void
+}) {
   const router = useRouter()
   const { theme, setTheme } = useTheme()
 
@@ -25,7 +30,7 @@ export default function CommandPalette() {
     }
     window.addEventListener('keydown', down)
     return () => window.removeEventListener('keydown', down)
-  }, [])
+  }, [setOpen])
 
   return (
     <Command.Dialog

--- a/src/components/MobileCommandButton.tsx
+++ b/src/components/MobileCommandButton.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function MobileCommandButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label="Open Command Menu"
+      className="fixed bottom-4 right-4 sm:hidden p-3 rounded-full border bg-background shadow-lg"
+    >
+      ⌘
+    </button>
+  )
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -3,14 +3,18 @@
 import { ThemeProvider } from 'next-themes'
 import { AnimatePresence, motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
+import { useState } from 'react'
 import CommandPalette from './CommandPalette'
 import ScrollNavigator from './ScrollNavigator'
+import MobileCommandButton from './MobileCommandButton'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const [commandOpen, setCommandOpen] = useState(false)
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-      <CommandPalette />
+      <CommandPalette open={commandOpen} setOpen={setCommandOpen} />
+      <MobileCommandButton onClick={() => setCommandOpen(true)} />
       <ScrollNavigator>
         <AnimatePresence mode="wait">
           <motion.div

--- a/src/components/ScrollNavigator.tsx
+++ b/src/components/ScrollNavigator.tsx
@@ -11,7 +11,8 @@ export default function ScrollNavigator({ children }: { children: React.ReactNod
 
   useEffect(() => {
     let last = 0
-    const onWheel = (e: WheelEvent) => {
+    let touchStart = 0
+    const navigate = (deltaY: number) => {
       const now = Date.now()
       if (now - last < 1000) return
       const index = order.indexOf(pathname)
@@ -21,16 +22,32 @@ export default function ScrollNavigator({ children }: { children: React.ReactNod
       const atBottom = window.innerHeight + window.scrollY >= doc.scrollHeight - 50
       const atTop = window.scrollY <= 50
 
-      if (e.deltaY > 50 && atBottom && index < order.length - 1) {
+      if (deltaY > 50 && atBottom && index < order.length - 1) {
         last = now
         router.push(order[index + 1])
-      } else if (e.deltaY < -50 && atTop && index > 0) {
+      } else if (deltaY < -50 && atTop && index > 0) {
         last = now
         router.push(order[index - 1])
       }
     }
+    const onWheel = (e: WheelEvent) => {
+      navigate(e.deltaY)
+    }
+    const onTouchStart = (e: TouchEvent) => {
+      touchStart = e.touches[0].clientY
+    }
+    const onTouchEnd = (e: TouchEvent) => {
+      const deltaY = touchStart - e.changedTouches[0].clientY
+      navigate(deltaY)
+    }
     window.addEventListener('wheel', onWheel, { passive: true })
-    return () => window.removeEventListener('wheel', onWheel)
+    window.addEventListener('touchstart', onTouchStart, { passive: true })
+    window.addEventListener('touchend', onTouchEnd, { passive: true })
+    return () => {
+      window.removeEventListener('wheel', onWheel)
+      window.removeEventListener('touchstart', onTouchStart)
+      window.removeEventListener('touchend', onTouchEnd)
+    }
   }, [pathname, router])
 
   return <>{children}</>


### PR DESCRIPTION
## Summary
- add floating command menu button for mobile
- restructure command palette for external toggle
- make scroll navigation work on touch devices
- update hero link to animate on tap

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687e91515adc83228dbafbbee5c2f517