### PR TITLE
Fix CommandPalette setOpen type

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@
 
 import { Command } from 'cmdk'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { useEffect, type Dispatch, type SetStateAction } from 'react'
 import { useTheme } from 'next-themes'
 
 const pages = [
@@ -16,7 +16,7 @@ export default function CommandPalette({
   setOpen,
 }: {
   open: boolean
-  setOpen: (open: boolean) => void
+  setOpen: Dispatch<SetStateAction<boolean>>
 }) {
   const router = useRouter()
   const { theme, setTheme } = useTheme()


### PR DESCRIPTION
## Summary
- fix `CommandPalette` type so setOpen accepts a function

## Testing
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687e99eb39048322baf359085795204b