### PR TITLE
Add not-found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+import ContentShell from '@/components/ContentShell'
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <ContentShell>
+      <h1 className="text-3xl font-bold mb-4">Page Not Found</h1>
+      <p className="mb-6 text-muted-foreground">
+        Sorry, the page you are looking for doesn’t exist.
+      </p>
+      <Link href="/" className="underline text-primary">
+        Go back home
+      </Link>
+    </ContentShell>
+  )
+}


### PR DESCRIPTION
## Summary
- add `not-found.tsx` to display a friendly message for unknown routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e9fe24e648322bc0830ca93045f02