### PR TITLE
Implement vertical timeline on About page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -19,8 +19,9 @@ export default function About() {
       </p>
 
       {/* Experience Timeline */}
-      <section className="space-y-10">
-        <TimelineItem icon={PartyPopper} title="Senior Staff Software Engineer, Google" period="Feb 2025 – Present • Atlanta, GA (Hybrid)">
+      <section>
+        <ol className="relative space-y-10 border-l border-muted-foreground/20 pl-10">
+          <TimelineItem icon={PartyPopper} title="Senior Staff Software Engineer, Google" period="Feb 2025 – Present • Atlanta, GA (Hybrid)">
           <li>
             Collaborate with Google Research to integrate&nbsp;
             <em>spiking neural networks (SNNs)</em> into scalable production systems.
@@ -35,9 +36,9 @@ export default function About() {
             hardware/software efforts.
           </li>
           <li>Publish internal white‑papers and contribute to open‑source tooling for brain‑inspired computing.</li>
-        </TimelineItem>
+          </TimelineItem>
 
-        <TimelineItem icon={Rocket} title="Staff Software Engineer, Google" period="Feb 2022 – Feb 2025">
+          <TimelineItem icon={Rocket} title="Staff Software Engineer, Google" period="Feb 2022 – Feb 2025">
           <li>
             Designed machine‑learning systems to optimize ad delivery and bidding strategies across Google Ads.
           </li>
@@ -46,17 +47,18 @@ export default function About() {
             Launched the Budgeting Optimization System (BOS) for dynamic ad‑spend allocation using reinforcement learning.
           </li>
           <li>Improved campaign outcomes through statistical modeling and continuous experimentation.</li>
-        </TimelineItem>
+          </TimelineItem>
 
-        <TimelineItem icon={Brain} title="Senior Software Engineer, Google" period="Jan 2020 – Feb 2022">
+          <TimelineItem icon={Brain} title="Senior Software Engineer, Google" period="Jan 2020 – Feb 2022">
           <li>Led a backend engineering team enhancing usability for Google Chat and Google Drive.</li>
           <li>Partnered with cross‑functional groups to identify user‑experience gaps and ship high‑impact improvements.</li>
-        </TimelineItem>
+          </TimelineItem>
 
-        <TimelineItem icon={Brain} title="Software Engineer, Google" period="Jan 2018 – Jan 2020">
+          <TimelineItem icon={Brain} title="Software Engineer, Google" period="Jan 2018 – Jan 2020">
           <li>Enhanced Google’s recommendation systems with machine learning and large‑scale data analysis.</li>
           <li>Delivered personalized suggestions that boosted user engagement across core properties.</li>
-        </TimelineItem>
+          </TimelineItem>
+        </ol>
       </section>
     </ContentShell>
   )

--- a/src/components/TimelineItem.tsx
+++ b/src/components/TimelineItem.tsx
@@ -11,44 +11,29 @@ export interface TimelineItemProps {
 }
 
 export default function TimelineItem({ icon: Icon, title, period, children }: TimelineItemProps) {
-  // Defensive: fallback if Icon is undefined
-  if (!Icon) {
-    return (
-      <motion.div
-        initial={{ opacity: 0, y: 10 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.35 }}
-        className="relative pl-10"
-      >
-        <div className="absolute left-0 top-1">
-          <span className="text-primary text-lg">?</span>
-        </div>
-        <h2 className="text-xl font-semibold">{title}</h2>
-        <p className="text-sm text-muted-foreground">{period}</p>
-        <ul className="list-disc ml-6 mt-2 space-y-1 text-base leading-relaxed">
-          {children}
-        </ul>
-      </motion.div>
-    )
+  const IconOrFallback = () => {
+    if (Icon) {
+      return <Icon className="h-4 w-4 text-primary" />
+    }
+    return <span className="text-primary text-sm">?</span>
   }
 
   return (
-    <motion.div
+    <motion.li
       initial={{ opacity: 0, y: 10 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.35 }}
       className="relative pl-10"
     >
-      <div className="absolute left-0 top-1">
-        <Icon className="text-primary" size={20} />
+      <div className="absolute left-0 top-1 -translate-x-1/2 flex h-6 w-6 items-center justify-center rounded-full bg-background ring-2 ring-primary">
+        <IconOrFallback />
       </div>
       <h2 className="text-xl font-semibold">{title}</h2>
       <p className="text-sm text-muted-foreground">{period}</p>
       <ul className="list-disc ml-6 mt-2 space-y-1 text-base leading-relaxed">
         {children}
       </ul>
-    </motion.div>
+    </motion.li>
   )
 }


### PR DESCRIPTION
## Summary
- convert `TimelineItem` to a list item
- add pin styling and motion to each item
- restructure About page experience section to render an ordered list with a connecting line

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687f9e9cac848322a09381a88256c97c