### PR TITLE
Implement timeline mapping

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,51 @@ import { Brain, PartyPopper, Rocket } from 'lucide-react'
 import ContentShell from '@/components/ContentShell'
 import TimelineItem from '@/components/TimelineItem'
 
+// Abstracting experience data into an array
+const experiences = [
+  {
+    icon: PartyPopper,
+    title: "Senior Staff Software Engineer, Google",
+    period: "Feb 2025 – Present • Atlanta, GA (Hybrid)",
+    points: [
+      "Collaborate with Google Research to integrate spiking neural networks (SNNs) into scalable production systems.",
+      "Lead design and development of neuromorphic algorithms optimized for edge AI devices.",
+      "Architect hybrid AI solutions that combine traditional deep-learning pipelines with brain-inspired components.",
+      "Prototype and deploy low-power AI accelerators on custom silicon, driving cross-functional hardware/software efforts.",
+      "Publish internal white-papers and contribute to open-source tooling for brain-inspired computing.",
+    ],
+  },
+  {
+    icon: Rocket,
+    title: "Staff Software Engineer, Google",
+    period: "Feb 2022 – Feb 2025",
+    points: [
+      "Designed machine-learning systems to optimize ad delivery and bidding strategies across Google Ads.",
+      "Built scalable real-time data pipelines and ML model-training infrastructure.",
+      "Launched the Budgeting Optimization System (BOS) for dynamic ad-spend allocation using reinforcement learning.",
+      "Improved campaign outcomes through statistical modeling and continuous experimentation.",
+    ],
+  },
+  {
+    icon: Brain,
+    title: "Senior Software Engineer, Google",
+    period: "Jan 2020 – Feb 2022",
+    points: [
+      "Led a backend engineering team enhancing usability for Google Chat and Google Drive.",
+      "Partnered with cross-functional groups to identify user-experience gaps and ship high-impact improvements.",
+    ],
+  },
+  {
+    icon: Brain,
+    title: "Software Engineer, Google",
+    period: "Jan 2018 – Jan 2020",
+    points: [
+      "Enhanced Google’s recommendation systems with machine learning and large-scale data analysis.",
+      "Delivered personalized suggestions that boosted user engagement across core properties.",
+    ],
+  },
+]
+
 export default function About() {
   return (
     <ContentShell>
@@ -19,47 +64,15 @@ export default function About() {
       </p>
 
       {/* Experience Timeline */}
-      <section>
-        <ol className="relative space-y-10 border-l border-muted-foreground/20 pl-10">
-          <TimelineItem icon={PartyPopper} title="Senior Staff Software Engineer, Google" period="Feb 2025 – Present • Atlanta, GA (Hybrid)">
-          <li>
-            Collaborate with Google Research to integrate&nbsp;
-            <em>spiking neural networks (SNNs)</em> into scalable production systems.
-          </li>
-          <li>Lead design and development of neuromorphic algorithms optimized for edge AI devices.</li>
-          <li>
-            Architect hybrid AI solutions that combine traditional deep‑learning pipelines with
-            brain‑inspired components.
-          </li>
-          <li>
-            Prototype and deploy low‑power AI accelerators on custom silicon, driving cross‑functional
-            hardware/software efforts.
-          </li>
-          <li>Publish internal white‑papers and contribute to open‑source tooling for brain‑inspired computing.</li>
+      <ol className="relative border-l border-border/50">
+        {experiences.map((exp, index) => (
+          <TimelineItem key={index} icon={exp.icon} title={exp.title} period={exp.period}>
+            {exp.points.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
           </TimelineItem>
-
-          <TimelineItem icon={Rocket} title="Staff Software Engineer, Google" period="Feb 2022 – Feb 2025">
-          <li>
-            Designed machine‑learning systems to optimize ad delivery and bidding strategies across Google Ads.
-          </li>
-          <li>Built scalable real‑time data pipelines and ML model‑training infrastructure.</li>
-          <li>
-            Launched the Budgeting Optimization System (BOS) for dynamic ad‑spend allocation using reinforcement learning.
-          </li>
-          <li>Improved campaign outcomes through statistical modeling and continuous experimentation.</li>
-          </TimelineItem>
-
-          <TimelineItem icon={Brain} title="Senior Software Engineer, Google" period="Jan 2020 – Feb 2022">
-          <li>Led a backend engineering team enhancing usability for Google Chat and Google Drive.</li>
-          <li>Partnered with cross‑functional groups to identify user‑experience gaps and ship high‑impact improvements.</li>
-          </TimelineItem>
-
-          <TimelineItem icon={Brain} title="Software Engineer, Google" period="Jan 2018 – Jan 2020">
-          <li>Enhanced Google’s recommendation systems with machine learning and large‑scale data analysis.</li>
-          <li>Delivered personalized suggestions that boosted user engagement across core properties.</li>
-          </TimelineItem>
-        </ol>
-      </section>
+        ))}
+      </ol>
     </ContentShell>
   )
 }

--- a/src/components/TimelineItem.tsx
+++ b/src/components/TimelineItem.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import type { LucideIcon } from 'lucide-react'
-import { motion } from 'framer-motion'
 
 export interface TimelineItemProps {
   icon: LucideIcon
@@ -11,29 +10,16 @@ export interface TimelineItemProps {
 }
 
 export default function TimelineItem({ icon: Icon, title, period, children }: TimelineItemProps) {
-  const IconOrFallback = () => {
-    if (Icon) {
-      return <Icon className="h-4 w-4 text-primary" />
-    }
-    return <span className="text-primary text-sm">?</span>
-  }
-
   return (
-    <motion.li
-      initial={{ opacity: 0, y: 10 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.35 }}
-      className="relative pl-10"
-    >
-      <div className="absolute left-0 top-1 -translate-x-1/2 flex h-6 w-6 items-center justify-center rounded-full bg-background ring-2 ring-primary">
-        <IconOrFallback />
-      </div>
-      <h2 className="text-xl font-semibold">{title}</h2>
-      <p className="text-sm text-muted-foreground">{period}</p>
-      <ul className="list-disc ml-6 mt-2 space-y-1 text-base leading-relaxed">
+    <li className="mb-10 ml-8">
+      <span className="absolute flex items-center justify-center w-8 h-8 bg-background rounded-full -left-4 ring-4 ring-background">
+        <Icon className="w-4 h-4 text-primary" />
+      </span>
+      <h2 className="text-xl font-semibold leading-tight">{title}</h2>
+      <p className="text-sm text-muted-foreground mt-0.5">{period}</p>
+      <ul className="list-disc ml-5 mt-3 space-y-2 text-base leading-relaxed text-muted-foreground">
         {children}
       </ul>
-    </motion.li>
+    </li>
   )
 }


### PR DESCRIPTION
## Summary
- create experience array and render About page timeline via `.map`
- simplify `TimelineItem` to a basic list item and pin style

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687fa0caf8a8832299860f3edb6f265d